### PR TITLE
Delivery and Management API specific options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@ ContentfulModel.configure do |config|
   config.environment = "master" # Optional - defaults to 'master'
   config.default_locale = "en-US" # Optional - defaults to 'en-US'
   config.options = { # Optional
-    # Extra options to send to the Contentful::Client
+    # Extra options to send to the Contentful::Client and Contentful::Management::Client
     # See https://github.com/contentful/contentful.rb#configuration
 
     # Optional:
-    # Use `delivery_api_only` and `management_api_only` keys to limit to what API the settings
-    # will apply. For example:
-    delivery_api_only: {
+    # Use `delivery_api` and `management_api` keys to limit to what API the settings
+    # will apply. Useful because Delivery API is usually visitor facing, while Management
+    # is used in background tasks that can run much longer. For example:
+    delivery_api: {
       timeout_read: 6
+    },
+    management_api: {
+      timeout_read: 100
     }
   }
 end

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ ContentfulModel.configure do |config|
   config.environment = "master" # Optional - defaults to 'master'
   config.default_locale = "en-US" # Optional - defaults to 'en-US'
   config.options = { # Optional
-    #extra options to send to the Contentful::Client
+    # Extra options to send to the Contentful::Client
+    # See https://github.com/contentful/contentful.rb#configuration
+
+    # Optional:
+    # Use `delivery_api_only` and `management_api_only` keys to limit to what API the settings
+    # will apply. For example:
+    delivery_api_only: {
+      timeout_read: 6
+    }
   }
 end
 

--- a/lib/contentful_model/client.rb
+++ b/lib/contentful_model/client.rb
@@ -23,8 +23,6 @@ module ContentfulModel
         raise_for_empty_fields: false
       }.merge(configuration)
 
-      ::Rails.logger.debug "ContentfulModel::Client#initialize #{configuration}"
-
       if configuration[:delivery_api_only]
         configuration.merge!(configuration[:delivery_api_only])
       end

--- a/lib/contentful_model/client.rb
+++ b/lib/contentful_model/client.rb
@@ -14,13 +14,22 @@ module ContentfulModel
         configuration[:api_url] = PREVIEW_API_URL
         configuration[:access_token] = configuration[:preview_access_token]
       end
-      super({
+
+      configuration = {
         raise_errors: true,
         dynamic_entries: :auto,
         integration_name: 'contentful_model',
         integration_version: ::ContentfulModel::VERSION,
         raise_for_empty_fields: false
-      }.merge(configuration))
+      }.merge(configuration)
+
+      ::Rails.logger.debug "ContentfulModel::Client#initialize #{configuration}"
+
+      if configuration[:delivery_api_only]
+        configuration.merge!(configuration[:delivery_api_only])
+      end
+
+      super(configuration)
     end
   end
 end

--- a/lib/contentful_model/client.rb
+++ b/lib/contentful_model/client.rb
@@ -23,8 +23,8 @@ module ContentfulModel
         raise_for_empty_fields: false
       }.merge(configuration)
 
-      if configuration[:delivery_api_only]
-        configuration.merge!(configuration[:delivery_api_only])
+      if configuration[:delivery_api]
+        configuration.merge!(configuration[:delivery_api])
       end
 
       super(configuration)

--- a/lib/contentful_model/management.rb
+++ b/lib/contentful_model/management.rb
@@ -8,8 +8,6 @@ module ContentfulModel
         options.merge!(options[:management_api_only])
       end
 
-      ::Rails.logger.debug "ContentfulModel::Management#initialize #{options}"
-
       super(ContentfulModel.configuration.management_token, options)
     end
   end

--- a/lib/contentful_model/management.rb
+++ b/lib/contentful_model/management.rb
@@ -4,8 +4,8 @@ module ContentfulModel
     def initialize(options = {})
       options = ContentfulModel.configuration.to_hash.merge!(options)
 
-      if options[:management_api_only]
-        options.merge!(options[:management_api_only])
+      if options[:management_api]
+        options.merge!(options[:management_api])
       end
 
       super(ContentfulModel.configuration.management_token, options)

--- a/lib/contentful_model/management.rb
+++ b/lib/contentful_model/management.rb
@@ -4,6 +4,12 @@ module ContentfulModel
     def initialize(options = {})
       options = ContentfulModel.configuration.to_hash.merge!(options)
 
+      if options[:management_api_only]
+        options.merge!(options[:management_api_only])
+      end
+
+      ::Rails.logger.debug "ContentfulModel::Management#initialize #{options}"
+
       super(ContentfulModel.configuration.management_token, options)
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,12 +5,12 @@ describe ContentfulModel::Client do
     described_class.new({
       space: 'cfexampleapi',
       access_token: 'b4c0n73n7fu1',
-      management_api_only: {
+      management_api: {
         timeout_connect: 3,
         timeout_read: 6,
         timeout_write: 20
       },
-      delivery_api_only: {
+      delivery_api: {
         timeout_connect: 4,
         timeout_read: 7,
         timeout_write: 21

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,11 +1,30 @@
 require 'spec_helper'
 
 describe ContentfulModel::Client do
-  subject { described_class.new({space: 'cfexampleapi', access_token: 'b4c0n73n7fu1'}) }
+  subject do
+    described_class.new({
+      space: 'cfexampleapi',
+      access_token: 'b4c0n73n7fu1',
+      management_api_only: {
+        timeout_connect: 3,
+        timeout_read: 6,
+        timeout_write: 20
+      },
+      delivery_api_only: {
+        timeout_connect: 4,
+        timeout_read: 7,
+        timeout_write: 21
+      }
+    })
+  end
 
   it 'is a Contentful::Client' do
     vcr('client') {
       expect(subject).to be_a(Contentful::Client)
     }
+  end
+
+  it 'gets initialized with the configured delivery specific timeout_read' do
+    expect(subject.configuration[:timeout_connect]).to eq(4)
   end
 end

--- a/spec/management_spec.rb
+++ b/spec/management_spec.rb
@@ -4,6 +4,14 @@ describe ContentfulModel::Management do
   before do
     ContentfulModel.configure do |c|
       c.management_token = 'foobar'
+      c.options = {
+        management_api_only: {
+          timeout_read: 6
+        },
+        delivery_api_only: {
+          timeout_read: 7
+        }
+      }
     end
   end
 
@@ -13,5 +21,9 @@ describe ContentfulModel::Management do
 
   it 'gets initialized with the configured management token' do
     expect(subject.access_token).to eq('foobar')
+  end
+
+  it 'gets initialized with the configured management specific timeout_read' do
+    expect(subject.configuration[:timeout_read]).to eq(6)
   end
 end

--- a/spec/management_spec.rb
+++ b/spec/management_spec.rb
@@ -5,10 +5,10 @@ describe ContentfulModel::Management do
     ContentfulModel.configure do |c|
       c.management_token = 'foobar'
       c.options = {
-        management_api_only: {
+        management_api: {
           timeout_read: 6
         },
-        delivery_api_only: {
+        delivery_api: {
           timeout_read: 7
         }
       }


### PR DESCRIPTION
This is to allow to pass different configuration values of the same option to Delivery and Management clients.

It's needed if we want to say configure the Delivery API to fail quickly as we don't want to hog page rendering, and on the other hand let Management API take as long as needed in the same app, as those queries are not run by visitors and don't have to be fast.

```
config.options = {
    # Optional:
    # Use `delivery_api` and `management_api` keys to limit to what API the settings
    # will apply. Useful because Delivery API is usually visitor facing, while Management
    # is used in background tasks that can run much longer. For example:
    delivery_api: {
      timeout_read: 6
    },
    management_api: {
      timeout_read: 100
    }
}
```